### PR TITLE
fix: duplicate refresh token calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In a production environment, with a proper JWT generating API, and a proper JWT 
 
 Provide an answer below:
 
-> DELETE THIS QUOTE AND REPLACE IT WITH YOUR ANSWER
+**We should not make unecessary requests to the auth service, as it can lead to rate limit exhaustion or throttling. It's also a waste of network, database and CPU resources, and the duplicate requests could lead to race conditions when trying to authenticate, resulting in a bad UX, bugs and mad users. If the refresh token endpoint generates a new valid token for each concurrent request, this could also be a security issue.**
 
 ---
 

--- a/src/services/login/__tests__/api.test.ts
+++ b/src/services/login/__tests__/api.test.ts
@@ -1,0 +1,286 @@
+import { LoginApiService } from '../api';
+import { LoginResponseData } from '../interface';
+
+const mockFetchPost = jest.fn();
+const mockConsoleLog = jest.fn();
+
+const localStorageMock = {
+	getItem: jest.fn(),
+	setItem: jest.fn(),
+	removeItem: jest.fn(),
+};
+
+Object.defineProperty(window, 'localStorage', {
+	value: localStorageMock,
+	writable: true,
+});
+
+Object.defineProperty(console, 'log', {
+	value: mockConsoleLog,
+	writable: true,
+});
+
+class TestableLoginApiService extends LoginApiService {
+	public mockParseJwt = jest.fn();
+
+	protected parseJwt(token: string) {
+		return this.mockParseJwt(token);
+	}
+
+	protected async fetchPost(endpoint: string, options: any, body: any): Promise<any> {
+		return mockFetchPost(endpoint, options, body);
+	}
+
+	public testStoreInLocalStorage(payload: LoginResponseData) {
+		localStorage.setItem('loginData', JSON.stringify(payload));
+	}
+
+	public testRetrieveFromLocalStorage(): LoginResponseData | null {
+		try {
+			const serializedLoginData = localStorage.getItem('loginData');
+			if (!serializedLoginData) {
+				throw new Error('Not logged in');
+			}
+			return JSON.parse(serializedLoginData);
+		} catch {
+			return null;
+		}
+	}
+}
+
+describe('LoginApiService', () => {
+	let service: TestableLoginApiService;
+	const mockToken: LoginResponseData = {
+		access: 'mock.access.token',
+		refresh: 'mock.refresh.token',
+	};
+
+	const mockRefreshedToken: LoginResponseData = {
+		access: 'new.access.token',
+		refresh: 'new.refresh.token',
+	};
+
+	beforeEach(() => {
+		service = new TestableLoginApiService();
+
+		mockFetchPost.mockReset();
+		mockConsoleLog.mockReset();
+		localStorageMock.getItem.mockReset();
+		localStorageMock.setItem.mockReset();
+		localStorageMock.removeItem.mockReset();
+		service.mockParseJwt.mockReset();
+	});
+
+	describe('getValidToken', () => {
+		it('should return null when no token exists in localStorage', async () => {
+			localStorageMock.getItem.mockReturnValue(null);
+
+			const result = await service.getValidToken();
+
+			expect(result).toBeNull();
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('loginData');
+		});
+
+		it('should return null when token exists but has no access property', async () => {
+			const invalidToken = { refresh: 'mock.refresh.token' };
+			localStorageMock.getItem.mockReturnValue(JSON.stringify(invalidToken));
+
+			const result = await service.getValidToken();
+
+			expect(result).toBeNull();
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('loginData');
+		});
+
+		it('should return current token when it is still valid', async () => {
+			const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour in the future
+
+			localStorageMock.getItem.mockReturnValue(JSON.stringify(mockToken));
+			service.mockParseJwt.mockReturnValue({ exp: futureTimestamp });
+
+			const result = await service.getValidToken();
+
+			expect(result).toEqual(mockToken);
+			expect(mockFetchPost).not.toHaveBeenCalled();
+		});
+
+		it('should refresh token when it is expired', async () => {
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour in the past
+
+			localStorageMock.getItem
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockRefreshedToken));
+
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+			mockFetchPost.mockResolvedValue(mockRefreshedToken);
+
+			const result = await service.getValidToken();
+
+			expect(result).toEqual(mockRefreshedToken);
+			expect(mockFetchPost).toHaveBeenCalledWith(
+				'/refresh/',
+				{ method: 'POST' },
+				{ refresh: mockToken.refresh }
+			);
+			expect(localStorageMock.setItem).toHaveBeenCalledWith(
+				'loginData',
+				JSON.stringify(mockRefreshedToken)
+			);
+		});
+
+		it('should handle refresh errors gracefully', async () => {
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+
+			localStorageMock.getItem.mockReturnValue(JSON.stringify(mockToken));
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+			mockFetchPost.mockRejectedValue(new Error('Refresh failed'));
+
+			const result = await service.getValidToken();
+
+			expect(result).toBeNull();
+			expect(mockConsoleLog).toHaveBeenCalled();
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('loginData');
+		});
+
+		it('should handle concurrent refresh requests - only one refresh should be triggered', async () => {
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+
+			localStorageMock.getItem
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValue(JSON.stringify(mockRefreshedToken));
+
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+
+			let resolveRefresh: (value: LoginResponseData) => void;
+			const refreshPromise = new Promise<LoginResponseData>((resolve) => {
+				resolveRefresh = resolve;
+			});
+			mockFetchPost.mockReturnValue(refreshPromise);
+
+			// Make 3 concurrent calls
+			const promise1 = service.getValidToken();
+			const promise2 = service.getValidToken();
+			const promise3 = service.getValidToken();
+
+			await new Promise(resolve => setTimeout(resolve, 10));
+			expect(mockFetchPost).toHaveBeenCalledTimes(1);
+
+			resolveRefresh!(mockRefreshedToken);
+
+			const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3]);
+
+			expect(result1).toEqual(mockRefreshedToken);
+			expect(result2).toEqual(mockRefreshedToken);
+			expect(result3).toEqual(mockRefreshedToken);
+
+			expect(mockFetchPost).toHaveBeenCalledTimes(1);
+			expect(mockFetchPost).toHaveBeenCalledWith(
+				'/refresh/',
+				{ method: 'POST' },
+				{ refresh: mockToken.refresh }
+			);
+		});
+
+		it('should handle concurrent refresh requests with error - all should return null', async () => {
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+
+			localStorageMock.getItem
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValue(null);
+
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+
+			let rejectRefresh: (error: Error) => void;
+			const refreshPromise = new Promise<LoginResponseData>((_, reject) => {
+				rejectRefresh = reject;
+			});
+			mockFetchPost.mockReturnValue(refreshPromise);
+
+			const promise1 = service.getValidToken();
+			const promise2 = service.getValidToken();
+			const promise3 = service.getValidToken();
+
+			await new Promise(resolve => setTimeout(resolve, 10));
+
+			expect(mockFetchPost).toHaveBeenCalledTimes(1);
+
+			rejectRefresh!(new Error('Refresh failed'));
+
+			const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3]);
+
+			expect(result1).toBeNull();
+			expect(result2).toBeNull();
+			expect(result3).toBeNull();
+
+			expect(mockFetchPost).toHaveBeenCalledTimes(1);
+			expect(mockConsoleLog).toHaveBeenCalledTimes(3);
+		});
+
+		it('should reset refresh promise after completion', async () => {
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+
+			localStorageMock.getItem
+				.mockReturnValueOnce(JSON.stringify(mockToken))
+				.mockReturnValueOnce(JSON.stringify(mockRefreshedToken))
+				.mockReturnValueOnce(JSON.stringify(mockRefreshedToken))
+				.mockReturnValueOnce(JSON.stringify(mockRefreshedToken));
+
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+			mockFetchPost.mockResolvedValue(mockRefreshedToken);
+
+			const result1 = await service.getValidToken();
+			expect(result1).toEqual(mockRefreshedToken);
+			expect(mockFetchPost).toHaveBeenCalledTimes(1);
+
+			service.mockParseJwt.mockReturnValue({ exp: pastTimestamp });
+
+			const result2 = await service.getValidToken();
+			expect(result2).toEqual(mockRefreshedToken);
+			expect(mockFetchPost).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('login', () => {
+		it('should store token in localStorage after successful login', async () => {
+			const loginData = { email: 'test@example.com', password: 'password' };
+			mockFetchPost.mockResolvedValue(mockToken);
+
+			const result = await service.login(loginData);
+
+			expect(result).toEqual(mockToken);
+			expect(localStorageMock.setItem).toHaveBeenCalledWith(
+				'loginData',
+				JSON.stringify(mockToken)
+			);
+		});
+	});
+
+	describe('logout', () => {
+		it('should remove token from localStorage', () => {
+			service.logout();
+
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('loginData');
+		});
+	});
+
+	describe('getCurrentToken', () => {
+		it('should return token from localStorage', async () => {
+			localStorageMock.getItem.mockReturnValue(JSON.stringify(mockToken));
+
+			const result = await service.getCurrentToken();
+
+			expect(result).toEqual(mockToken);
+		});
+
+		it('should return null if no token in localStorage', async () => {
+			localStorageMock.getItem.mockReturnValue(null);
+
+			const result = await service.getCurrentToken();
+
+			expect(result).toBeNull();
+		});
+	});
+}); 

--- a/src/services/login/__tests__/integration.test.ts
+++ b/src/services/login/__tests__/integration.test.ts
@@ -1,0 +1,115 @@
+import { AuthedService } from '../../base/authedService';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const localStorageMock = {
+	getItem: jest.fn(),
+	setItem: jest.fn(),
+	removeItem: jest.fn(),
+};
+
+Object.defineProperty(window, 'localStorage', {
+	value: localStorageMock,
+	writable: true,
+});
+
+describe('Integration: Concurrent API calls with expired JWT', () => {
+	let authedService1: AuthedService;
+	let authedService2: AuthedService;
+
+	const expiredToken = {
+		access: 'expired.jwt.token',
+		refresh: 'valid.refresh.token',
+	};
+
+	const refreshedToken = {
+		access: 'new.access.token',
+		refresh: 'new.refresh.token',
+	};
+
+	beforeEach(() => {
+		authedService1 = new AuthedService();
+		authedService2 = new AuthedService();
+
+		mockFetch.mockReset();
+		localStorageMock.getItem.mockReset();
+		localStorageMock.setItem.mockReset();
+		localStorageMock.removeItem.mockReset();
+
+		process.env.REACT_APP_API_URL = 'http://localhost:8000';
+	});
+
+	it('should only trigger one refresh when multiple API calls are made with expired token', async () => {
+		const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+		const expiredJwtPayload = btoa(JSON.stringify({ exp: pastTimestamp }));
+		const mockExpiredToken = {
+			...expiredToken,
+			access: `header.${expiredJwtPayload}.signature`
+		};
+
+		localStorageMock.getItem
+			.mockReturnValueOnce(JSON.stringify(mockExpiredToken))
+			.mockReturnValueOnce(JSON.stringify(mockExpiredToken))
+			.mockReturnValue(JSON.stringify(refreshedToken));
+
+		let refreshResolve: (value: any) => void;
+		const refreshPromise = new Promise((resolve) => {
+			refreshResolve = resolve;
+		});
+
+		mockFetch.mockImplementation((url: string) => {
+			if (url.includes('/refresh')) {
+				return refreshPromise;
+			} else if (url.includes('/brands')) {
+				return Promise.resolve({
+					ok: true,
+					headers: { get: () => 'application/json' },
+					json: () => Promise.resolve({ brands: [] })
+				});
+			} else if (url.includes('/users/me')) {
+				return Promise.resolve({
+					ok: true,
+					headers: { get: () => 'application/json' },
+					json: () => Promise.resolve({ user: {} })
+				});
+			}
+			return Promise.reject(new Error('Unexpected URL'));
+		});
+
+		const brandsCall = authedService1.get('/brands');
+		const userCall = authedService2.get('/users/me');
+
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		refreshResolve!({
+			ok: true,
+			headers: { get: () => 'application/json' },
+			json: () => Promise.resolve(refreshedToken)
+		});
+		const [brandsResult, userResult] = await Promise.all([brandsCall, userCall]);
+
+		expect(brandsResult).toEqual({ brands: [] });
+		expect(userResult).toEqual({ user: {} });
+
+		const refreshCalls = mockFetch.mock.calls.filter(call =>
+			call[0].includes('/refresh')
+		);
+		expect(refreshCalls).toHaveLength(1);
+
+		expect(refreshCalls[0][1]).toEqual({
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ refresh: 'valid.refresh.token' })
+		});
+
+		const apiCalls = mockFetch.mock.calls.filter(call =>
+			call[0].includes('/brands') || call[0].includes('/users/me')
+		);
+		expect(apiCalls).toHaveLength(2);
+
+		apiCalls.forEach(call => {
+			expect(call[1].headers.Authorization).toBe('Bearer new.access.token');
+		});
+	});
+}); 

--- a/src/services/login/api.ts
+++ b/src/services/login/api.ts
@@ -1,6 +1,8 @@
 import { LoginService, LoginRequestData, LoginResponseData } from "./interface";
 
 export class LoginApiService extends LoginService {
+  private refreshPromise: Promise<LoginResponseData> | null = null;
+
   public async login(payload: LoginRequestData): Promise<LoginResponseData> {
     const response: LoginResponseData = await this.fetchPost(
       "/login/",
@@ -31,20 +33,33 @@ export class LoginApiService extends LoginService {
     try {
       const parsedToken = this.parseJwt(token?.access);
 
-      if (new Date().getTime() / 1000 > parsedToken.exp) {
-        const response: LoginResponseData = await this.fetchPost(
-          "/refresh/",
-          { method: "POST" },
-          { refresh: token.refresh }
-        );
-        this.storeInLocalStorage(response);
+      if (new Date().getTime() / 1000 < parsedToken.exp) {
+        return this.retrieveFromLocalStorage();
       }
+
+      if (this.refreshPromise) {
+        await this.refreshPromise;
+        return this.retrieveFromLocalStorage();
+      }
+
+      this.refreshPromise = this.fetchPost(
+        "/refresh/",
+        { method: "POST" },
+        { refresh: token.refresh }
+      );
+
+      const response = await this.refreshPromise;
+      this.storeInLocalStorage(response);
+
       return this.retrieveFromLocalStorage();
+
     } catch (e) {
       console.log(e);
       this.logout();
+      return null;
+    } finally {
+      this.refreshPromise = null;
     }
-    return null;
   }
 
   private loginDataKey = "loginData";
@@ -70,7 +85,7 @@ export class LoginApiService extends LoginService {
   };
 
   // https://stackoverflow.com/questions/38552003/how-to-decode-jwt-token-in-javascript-without-using-a-library
-  private parseJwt(token: string) {
+  protected parseJwt(token: string) {
     var base64Url = token.split(".")[1];
     var base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
     var jsonPayload = decodeURIComponent(


### PR DESCRIPTION
## Problem
Duplicate requests were being made to the refresh endpoint when authenticating.

## Solution
Implement token refresh logic to prevent unnecessary requests and improve UX.

## Tests
Added tests for login and token handling.

## How to verify
- Open the browser developer tools
- Refresh the page
- Only ONE call to /refresh has been made